### PR TITLE
修复 多个子包单独使用 mpvue 构建，然后集成到一个项目中后， 造成页面重复注册的问题

### DIFF
--- a/JsonpMainTemplatePlugin.js
+++ b/JsonpMainTemplatePlugin.js
@@ -148,7 +148,6 @@ class JsonpMainTemplatePlugin {
               "}"
             ]),
             "}",
-            "if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);",
             "while(resolves.length) {",
             this.indent("resolves.shift()();"),
             "}",


### PR DESCRIPTION
修复 多个子包单独使用 mpvue 构建，然后集成到一个项目中后， 造成页面重复注册的问题