### PR TITLE
修复 多个子包单独使用 mpvue 构建，然后集成到一个项目中后， 造成页面重复注册的问题

### DIFF
--- a/JsonpMainTemplatePlugin.js
+++ b/JsonpMainTemplatePlugin.js
@@ -126,7 +126,6 @@ class JsonpMainTemplatePlugin {
           source,
           "",
           "// install a JSONP callback for chunk loading",
-          `var parentJsonpFunction = global[${JSON.stringify(jsonpFunction)}];`,
           `global[${JSON.stringify(jsonpFunction)}] = function webpackJsonpCallback(chunkIds, moreModules, executeModules) {`,
           this.indent([
             "// add \"moreModules\" to the modules object,",
@@ -148,7 +147,6 @@ class JsonpMainTemplatePlugin {
               "}"
             ]),
             "}",
-            "if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);",
             "while(resolves.length) {",
             this.indent("resolves.shift()();"),
             "}",


### PR DESCRIPTION
修复 多个子包单独使用 mpvue 构建，然后集成到一个项目中后， 造成页面重复注册的问题，删除调用与声明